### PR TITLE
fix user registration

### DIFF
--- a/site/common/database.php
+++ b/site/common/database.php
@@ -999,7 +999,7 @@ function registerUser($dbh, &$output, $name, $email, $adminEmail) {
    $hash = strtoupper(substr($output['user_hash'], 0, 8));
    $subject = mysqli_real_escape_string('Welcome to Crowdcast!');
    $body = mysqli_real_escape_string(sprintf("Hi %s,\r\n\r\nWelcome to Crowdcast (formerly known as Epicast)! Here's your User ID: %s\r\nYou can login and begin forecasting here: https://delphi.cmu.edu/epicast/launch.php?user=%s\r\n\r\nThank you,\r\nThe Delphi Team\r\n\r\n[This is an automated message. Please direct all replies to: %s. Unsubscribe: https://delphi.cmu.edu/epicast/preferences.php?user=%s]", $name, $hash, $hash, $adminEmail, $hash));
-   $dbh->query("INSERT INTO automation.email_queue (`from`, `to`, `subject`, `body`) VALUES ('delphi@epicast.net', '{$email}', '{$subject}', '{$body}')");
+   $dbh->query("INSERT INTO automation.email_queue (`from`, `to`, `subject`, `body`, `priority`, `timestamp`) VALUES ('delphi@epicast.net', '{$email}', '{$subject}', '{$body}', 0.9, UNIX_TIMESTAMP(NOW()))");
    $dbh->query("CALL automation.RunStep(2)");
    setResult($output, 1);
    return getResult($output);


### PR DESCRIPTION
- database was updated with two new fields
- use priority 0.9 to allow registration email to get through ahead of 
most other emails
- use current timestamp